### PR TITLE
limit number of hours/mileage that can be logged

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -961,9 +961,3 @@ DEPENDENCIES
   uglifier
   unicorn
   webmock
-
-RUBY VERSION
-   ruby 2.4.2p198
-
-BUNDLED WITH
-   1.16.6

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -49,6 +49,6 @@ class ProjectsController < ApplicationController
 
   def project_params
     params.require(:project).
-      permit(:name, :billable, :client_id, :archived, :description, :budget)
+      permit(:name, :billable, :client_id, :archived, :description, :budget, :max_hours)
   end
 end

--- a/app/models/hour.rb
+++ b/app/models/hour.rb
@@ -34,6 +34,7 @@ class Hour < Entry
   }
 
   before_save :set_tags_from_description
+  before_validation :allowed_hours
 
   def tag_list
     tags.map(&:name).join(", ")
@@ -41,6 +42,10 @@ class Hour < Entry
 
   def self.query(params, includes = nil)
     EntryQuery.new(self.includes(includes).by_date, params, "hours").filter
+  end
+
+  def allowed_hours
+    errors.add(:value, "over allowed hours") if value > project.max_hours
   end
 
   private

--- a/app/models/mileage.rb
+++ b/app/models/mileage.rb
@@ -20,7 +20,15 @@ class Mileage < Entry
     where.not("projects.client_id" => nil).joins(:project)
   }
 
+  before_validation :allowed_distance
+
+  MAX_ALLOWED_DISTANCE = 100
+
   def self.query(params, includes = nil)
     EntryQuery.new(self.includes(includes).by_date, params, "mileages").filter
+  end
+
+  def allowed_distance
+    errors.add(:value, "over allowed distance") if value > MAX_ALLOWED_DISTANCE
   end
 end

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -4,6 +4,7 @@
     = f.input :name, required: true
     = f.input :description, as: :text, input_html: { rows: 5 }
     = f.input :budget, as: :integer
+    = f.input :max_hours, as: :integer
     = f.association :client, required: false, collection: Client.by_name, placeholder: t("project.form.client"), include_blank: t("project.form.no_client")
     = f.label :billable
     = f.input :billable, as: :switch, label: false

--- a/db/migrate/20190624232033_add_max_hours_to_projects.rb
+++ b/db/migrate/20190624232033_add_max_hours_to_projects.rb
@@ -1,0 +1,5 @@
+class AddMaxHoursToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :max_hours, :integer, default: 24
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150224115957) do
+ActiveRecord::Schema.define(version: 20190624232033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,11 +53,11 @@ ActiveRecord::Schema.define(version: 20150224115957) do
   end
 
   create_table "clients", force: :cascade do |t|
-    t.string   "name",              default: "", null: false
-    t.string   "description",       default: ""
+    t.string   "name",                        default: "", null: false
+    t.string   "description",                 default: ""
     t.string   "logo_file_name"
     t.string   "logo_content_type"
-    t.integer  "logo_file_size"
+    t.integer  "logo_file_size",    limit: 8
     t.datetime "logo_updated_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 20150224115957) do
     t.integer  "client_id"
     t.boolean  "archived",    default: false, null: false
     t.text     "description"
+    t.integer  "max_hours",   default: 24
   end
 
   add_index "projects", ["archived"], name: "index_projects_on_archived", using: :btree

--- a/spec/models/hour_spec.rb
+++ b/spec/models/hour_spec.rb
@@ -128,4 +128,20 @@ describe Hour do
       expect(entries).to include(entry_3, entry_4, entry_5)
     end
   end
+
+  describe "max allowed hours" do
+    context "when user enters more than the allowed number of hours" do
+      let!(:project) { create(:project, max_hours: 16) }
+      let!(:category) { create(:category) }
+      let!(:user) { create(:user) }
+      let!(:hour) { create(:hour, project: project, category: category, user: user) }
+      it "returns an error" do
+        hour.value = 17
+        expect(hour).to_not be_valid
+        expect(hour.errors[:value]).to include "over allowed hours"
+        hour.value = 10
+        expect(hour).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/mileage_spec.rb
+++ b/spec/models/mileage_spec.rb
@@ -63,4 +63,19 @@ describe Mileage do
       expect(Mileage.with_clients.count).to eq(1)
     end
   end
+
+  describe "max allowed distance" do
+    context "when user enters a distance greater than the maximum allowed" do
+      let!(:project) { create(:project) }
+      let!(:user) { create(:user) }
+      let!(:mileage) { create(:mileage, project: project, user: user) }
+      it "returns an error" do
+        mileage.value = 110
+        expect(mileage).to_not be_valid
+        expect(mileage.errors[:value]).to include "over allowed distance"
+        mileage.value = 90
+        expect(mileage).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
- allow admins set max hours for hour related entries
- use a constant maximum distance for mileage entries

why: so admins can ensure that people aren't abusing the time tracker